### PR TITLE
feat: exposed wait until stopped running as a new route

### DIFF
--- a/lib/components/services/statebox-api/routes/actions/Wait-until-stopped-running.js
+++ b/lib/components/services/statebox-api/routes/actions/Wait-until-stopped-running.js
@@ -1,0 +1,16 @@
+module.exports = function waitUntilStoppedRunning (statebox, req, res, env) {
+  const options = {}
+  if (env.userId) options.userId = env.userId
+
+  statebox.waitUntilStoppedRunning(
+    req.params.executionName,
+    function (err) {
+      if (err) {
+        console.error(err)
+        res.status(500).send()
+      } else {
+        res.status(200).send()
+      }
+    }
+  )
+}

--- a/lib/components/services/statebox-api/routes/actions/index.js
+++ b/lib/components/services/statebox-api/routes/actions/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   SendTaskSuccess: require('./Send-task-success'),
   SendTaskHeartbeat: require('./Send-task-heartbeat'),
-  SendTaskRevivification: require('./Send-task-revivification')
+  SendTaskRevivification: require('./Send-task-revivification'),
+  WaitUntilStoppedRunning: require('./Wait-until-stopped-running')
 }


### PR DESCRIPTION
In the frontend, when we submit a form we need a way to make the state machine finish. This comes from adding the new feature of cardscript hooks so, for example, we can specify that we want to refresh the remit after the form has been submitted but we need the state machine to fully complete. From what I understand "SendTaskSuccess" goes to the next state/task of the state machine. Exposing the statebox service function WaitUntilStoppedRunning as an extra route in the statebox api allows you to make the state machine finish.